### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/leahych/check_cards/security/code-scanning/1](https://github.com/leahych/check_cards/security/code-scanning/1)

In general, fix this by adding an explicit `permissions` block to the workflow (either at the top level or within the `build` job) that grants only the minimal required scopes. For a simple Rust CI workflow that just checks out code and runs build/tests, `contents: read` is sufficient; no write permissions are needed.

The single best fix with no behavior change is to add a top‑level `permissions` block after the `on:` section (affecting all jobs) that sets `contents: read`. This ensures `actions/checkout@v4` can still read the repository, while preventing write operations by default. No other scopes are required by any of the referenced actions (`dtolnay/rust-toolchain`, `taiki-e/install-action`, `cargo llvm-cov nextest` execution).

Concretely, in `.github/workflows/rust.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `env:` block (between current lines 8 and 9). No imports or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
